### PR TITLE
Ommiting the prop

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -253,7 +253,7 @@ export default class Headroom extends Component {
     delete divProps.downTolerance
     delete divProps.pinStart
 
-    const { style, wrapperStyle, ...rest } = divProps
+    const { style, wrapperStyle, calcHeightOnResize, ...rest } = divProps
 
     let innerStyle = {
       position: this.props.disable || this.state.state === 'unfixed' ? 'relative' : 'fixed',


### PR DESCRIPTION
calcHeightOnResize is ommitted to avoid unknown prop warnings:

```
Uncaught (node:9556) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): Error: Warning: Exception thrown by hook while handling onBeforeMountComponent: E
rror: Warning: Unknown prop `calcHeightOnResize` on <div> tag. Remove this prop from the element. For details, see https://fb.me/react-unknown-prop
    in div (created by Headroom)
    in div (created by Headroom)

```